### PR TITLE
Adding view classes endpoint

### DIFF
--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -72,3 +72,13 @@ class ClassList(Resource):
             api.abort(400, str(e))
 
         return new_class, 201
+    
+    @api.response(200, 'Success')
+    def get(self):
+        """
+        Retrieve a list of all fitness classes.
+
+        Requires a valid Bearer token in the Authorization header.
+        """
+        classes = cls_db.get_all_classes()
+        return {'classes': classes}, 200

--- a/app/db/classes.py
+++ b/app/db/classes.py
@@ -77,3 +77,14 @@ def get_class_by_id(class_id: str) -> dict:
 
     cls = DB.get_collection(CLASS_COLLECTION).find_one({'_id': oid})
     return _class_to_dict(cls)
+
+def get_all_classes() -> list[dict]:
+    """
+    Retrieve all fitness classes from the database.
+
+    Returns:
+        A list of class dicts.
+    """
+    col = DB.get_collection(CLASS_COLLECTION)
+    classes = col.find()
+    return [_class_to_dict(cls) for cls in classes]


### PR DESCRIPTION
Added a new public endpoint `GET /classes/` to list all fitness classes.  
No authentication required. Returns JSON with all class fields: id, name, instructor, schedule, capacity, location, description, enrolled.

Linked Issues:  
Closes #4 
Closes #5 