### PR TITLE
Remove booked_members from GET /classes response

### DIFF
--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -80,6 +80,10 @@ class ClassList(Resource):
         Retrieve a list of all fitness classes.
         """
         classes = cls_db.get_all_classes()
+
+        for c in classes:
+            c.pop("booked_members", None)  
+
         return {'classes': classes}, 200
 
 


### PR DESCRIPTION
Closes #21 

Removes booked_members from the GET /classes response to avoid exposing member emails.