### PR TITLE
Add SendReminder endpoint to send reminder emails to booked members

### DIFF
--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -148,5 +148,69 @@ class ClassMembers(Resource):
             'booked_members': members,
         }, 200
 
+@api.route('/<string:class_id>/send-reminder')
+class SendReminder(Resource):
 
+    @jwt_required()
+    @api.response(200, 'Reminders sent successfully')
+    @api.response(403, 'Forbidden – trainer or admin role required')
+    @api.response(404, 'Class not found')
+    def post(self, class_id):
+        """
+        Send reminder emails to all members who booked this class.
+        Trainer or admin only.
 
+        Returns the email body for each member in the response (for testing/demo purposes).
+        """
+
+        # Check role
+        claims = get_jwt()
+        if claims['role'] not in ('trainer', 'admin'):
+            api.abort(403, 'Trainer or admin role required.')
+
+        # Fetch class
+        cls = cls_db.get_class_by_id(class_id)
+        if cls is None:
+            api.abort(404, 'Class not found.')
+
+        # Get booked members
+        booked_members = cls.get('booked_members', [])
+        if not booked_members:
+            return {'message': 'No members booked for this class.'}, 200
+
+        sent_emails = []
+
+        # Construct and “send” email to each booked member
+        for member_email in booked_members:
+            email_subject = f"Reminder: {cls['name']} on {cls['schedule']}"
+            email_body = f"""
+Hello {member_email},
+
+This is a reminder for the fitness class you booked:
+
+Class Name: {cls['name']}
+Instructor: {cls['instructor']}
+Date/Time: {cls['schedule']}
+Location: {cls['location']}
+Description: {cls.get('description', 'No description')}
+
+See you there!
+"""
+            # Simulate sending email (print/log)
+            print(f"Sending email to {member_email}:\n{email_body}")
+
+            # Collect email info to return in response
+            sent_emails.append({
+                "to": member_email,
+                "subject": email_subject,
+                "body": email_body.strip()  # strip extra whitespace
+            })
+
+        # Return all emails in the JSON response for testing/demo
+        return {
+            "message": f"Reminder emails sent to {len(sent_emails)} members.",
+            "class_id": class_id,
+            "class_name": cls['name'],
+            "schedule": cls['schedule'],
+            "emails": sent_emails
+        }, 200


### PR DESCRIPTION
- Adds POST /classes/<class_id>/send-reminder
- Trainer/admin only
- Sends simulated reminder emails to booked members

Closes #23 